### PR TITLE
[FIX] new-style install command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See [examples](./examples) for configuration samples.
 ## How to install
 
 ```
-go get -u github.com/QuantumGhost/wg-quick-go
+go install github.com/QuantumGhost/wg-quick-go@latest
 ```
 
 ## How does this work?


### PR DESCRIPTION
go wants people to install stuff like

go install github.com/QuantumGhost/wg-quick-go@latest

( go get is outdated )